### PR TITLE
Apply enqueue hook fixes

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -33,7 +33,7 @@ module Resque
           if klass.respond_to?(:scheduled)
             klass.scheduled(queue, klass.to_s, *args)
           else
-            Resque::Job.create(queue, klass, *args)
+            Resque.enqueue_to(queue, klass, *args)
           end
         else
           delayed_push(timestamp, job_to_hash_with_queue(queue, klass, args))

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -265,6 +265,26 @@ context 'DelayedQueue' do
     end
   end
 
+  test 'when Resque.inline = true, calls Resque#enqueue ' \
+       'when klass#scheduled is not defined' do
+    old_val = Resque.inline
+    begin
+      Resque.inline = true
+      assert_false(SomeFancyJob.respond_to?(:scheduled))
+      Resque.expects(:enqueue_to).with(:fancy, SomeFancyJob, 'foo', 'bar')
+      Resque.enqueue_at(Time.now + 10, SomeFancyJob, 'foo', 'bar')
+    ensure
+      Resque.inline = old_val
+    end
+  end
+
+  test 'enqueue_at calls Resque#enqueue when given a moment in the past' \
+       'when klass#scheduled is not defined' do
+    assert_false(SomeFancyJob.respond_to?(:scheduled))
+    Resque.expects(:enqueue_to).with(:fancy, SomeFancyJob, 'foo', 'bar')
+    Resque.enqueue_at(Time.now - 10, SomeFancyJob, 'foo', 'bar')
+  end
+
   test 'enqueue_next_item picks one job' do
     t = Time.now + 60
 


### PR DESCRIPTION
We need https://github.com/resque/resque-scheduler/pull/616 so that resque hooks are fired consistently for scheduled vs non-scheduled jobs. This fix has already been merged to the master branch of the main resque-scheduler repo, but was never released. The repository now appears abandoned (the last release was April 2019 and the last commit to master was April 2020). This branch selectively applies just the fix we currently need to the last released version of resque-scheduler.